### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/activity_open_reference.xml
+++ b/app/src/main/res/layout/activity_open_reference.xml
@@ -91,6 +91,7 @@
 
         <Button
             android:id="@+id/cancelNodeRef"
+            android:textColor="#DC0000"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="48dp"


### PR DESCRIPTION
The original text color of the component is '#FF4081', and the contrast between the text color ('#FF4081') and the background color ('#FAFAFA') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#DC0000') are as follows:
![image](https://user-images.githubusercontent.com/101503193/211339448-6cb54b2d-4d1c-4605-8e80-d9ca3306235e.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.